### PR TITLE
Feature/overcooked tomato recipes

### DIFF
--- a/cogrid/envs/overcooked/overcooked_features.py
+++ b/cogrid/envs/overcooked/overcooked_features.py
@@ -162,7 +162,7 @@ class LayoutID(feature.Feature):
 
 
 class OvercookedInventory(feature.Feature):
-    shape = (3,)
+    shape = (5,)
 
     def __init__(self, **kwargs):
         super().__init__(low=0, high=1, name="overcooked_inventory", **kwargs)
@@ -178,6 +178,8 @@ class OvercookedInventory(feature.Feature):
             overcooked_grid_objects.Onion,
             overcooked_grid_objects.OnionSoup,
             overcooked_grid_objects.Plate,
+            overcooked_grid_objects.Tomato,
+            overcooked_grid_objects.TomatoSoup
         ]
         encoding[objs.index(type(agent.inventory[0]))] = 1
         assert np.array_equal(self.shape, encoding.shape)

--- a/cogrid/envs/overcooked/overcooked_grid_objects.py
+++ b/cogrid/envs/overcooked/overcooked_grid_objects.py
@@ -311,7 +311,7 @@ class DeliveryZone(grid_object.GridObj):
     ) -> bool:
         """Delivery can be toggled by an agent with Soup"""
         toggling_agent_has_soup = any(
-            [isinstance(grid_obj, OnionSoup) for grid_obj in agent.inventory]
+            [isinstance(grid_obj, (OnionSoup, TomatoSoup)) for grid_obj in agent.inventory]
         )
 
         if toggling_agent_has_soup:

--- a/cogrid/envs/overcooked/overcooked_grid_objects.py
+++ b/cogrid/envs/overcooked/overcooked_grid_objects.py
@@ -46,6 +46,32 @@ class Onion(grid_object.GridObj):
 grid_object.register_object(Onion.object_id, Onion, scope="overcooked")
 
 
+class Tomato(grid_object.GridObj):
+    object_id = "tomato"
+    color = constants.Colors.Red
+    char = "t"
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(
+            state=0,
+            inventory_value=0.0,
+        )
+
+    def can_pickup(self, agent: grid_object.GridAgent) -> bool:
+        return True
+
+    def render(self, tile_img):
+        fill_coords(
+            tile_img, point_in_circle(cx=0.5, cy=0.5, r=0.3), self.color
+        )
+
+grid_object.register_object(Tomato.object_id, Tomato, scope="overcooked")
+
+
 class OnionStack(grid_object.GridObj):
     """An OnionStack is just an (infinite) pile of onions."""
 
@@ -76,6 +102,36 @@ grid_object.register_object(
 )
 
 
+class TomatoStack(grid_object.GridObj):
+    """A TomatoStack is just an (infinite) pile of tomatoes."""
+
+    object_id = "tomato_stack"
+    color = constants.Colors.Red
+    char = "T"
+
+    def can_pickup_from(self, agent: grid_object.GridAgent) -> bool:
+        return True
+
+    def pick_up_from(self, agent: grid_object.GridAgent) -> grid_object.GridObj:
+        return Tomato()
+
+    def render(self, tile_img: np.ndarray):
+        fill_coords(
+            tile_img, point_in_circle(cx=0.25, cy=0.3, r=0.2), self.color
+        )
+        fill_coords(
+            tile_img, point_in_circle(cx=0.75, cy=0.3, r=0.2), self.color
+        )
+        fill_coords(
+            tile_img, point_in_circle(cx=0.5, cy=0.7, r=0.2), self.color
+        )
+
+
+grid_object.register_object(
+    TomatoStack.object_id, TomatoStack, scope="overcooked"
+)
+
+
 class Pot(grid_object.GridObj):
     object_id = "pot"
     color = constants.Colors.Grey
@@ -86,7 +142,7 @@ class Pot(grid_object.GridObj):
         self,
         state: int = 0,
         capacity: int = 3,
-        legal_contents: list[grid_object.GridObj] = [Onion],
+        legal_contents: list[grid_object.GridObj] = [Onion, Tomato],
         *args,
         **kwargs,
     ):
@@ -307,3 +363,35 @@ class OnionSoup(grid_object.GridObj):
 
 
 grid_object.register_object(OnionSoup.object_id, OnionSoup, scope="overcooked")
+
+
+class TomatoSoup(grid_object.GridObj):
+    object_id = "tomato_soup"
+    color = constants.Colors.Red
+    char = "!"
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(
+            state=0,
+            inventory_value=0.0,
+        )
+
+    def can_pickup(self, agent: grid_object.GridAgent) -> bool:
+        return True
+
+    def render(self, tile_img):
+        # Draw plate
+        fill_coords(
+            tile_img, point_in_circle(cx=0.5, cy=0.5, r=0.5), Plate.color
+        )
+
+        # draw soup inside plate
+        fill_coords(
+            tile_img,
+            point_in_circle(cx=0.5, cy=0.5, r=0.3),
+            self.color,
+        )

--- a/cogrid/envs/overcooked/overcooked_grid_objects.py
+++ b/cogrid/envs/overcooked/overcooked_grid_objects.py
@@ -407,3 +407,5 @@ class TomatoSoup(grid_object.GridObj):
             point_in_circle(cx=0.5, cy=0.5, r=0.3),
             self.color,
         )
+
+grid_object.register_object(TomatoSoup.object_id, TomatoSoup, scope="overcooked")

--- a/cogrid/envs/overcooked/overcooked_grid_objects.py
+++ b/cogrid/envs/overcooked/overcooked_grid_objects.py
@@ -184,7 +184,7 @@ class Pot(grid_object.GridObj):
 
         # return true if cell is the same ingredient type as other ingredients in the pot
         is_same_type = all(
-            [isinstance(cell, grid_obj) for grid_obj in self.objects_in_pot]
+            [isinstance(cell, type(grid_obj)) for grid_obj in self.objects_in_pot]
         )  # return true even if pot is empty
 
         return len(self.objects_in_pot) < self.capacity and \

--- a/cogrid/envs/overcooked/overcooked_grid_objects.py
+++ b/cogrid/envs/overcooked/overcooked_grid_objects.py
@@ -162,21 +162,33 @@ class Pot(grid_object.GridObj):
         )
 
     def pick_up_from(self, agent: grid_object.GridAgent) -> grid_object.GridObj:
+        # if all ingredients are tomatoes, return TomatoSoup
+        soup = OnionSoup()
+        if all(
+            [isinstance(grid_obj, Tomato) for grid_obj in self.objects_in_pot]
+        ):
+            soup = TomatoSoup()
+
         self.objects_in_pot = []
         self.cooking_timer = self.cooking_time
         agent.inventory.pop(0)  # TODO(chase): assumes size 1 inventory
-        return OnionSoup()
+        return soup
 
     def can_place_on(
         self, agent: grid_object.GridAgent, cell: grid_object.GridObj
     ) -> bool:
-        """Can only place onions in the soup!"""
-        if not any(
-            [isinstance(cell, grid_obj) for grid_obj in self.legal_contents]
-        ):
-            return False
 
-        return len(self.objects_in_pot) < self.capacity
+        is_legal_ingredient = any(
+            [isinstance(cell, grid_obj) for grid_obj in self.legal_contents]
+        )
+
+        # return true if cell is the same ingredient type as other ingredients in the pot
+        is_same_type = all(
+            [isinstance(cell, grid_obj) for grid_obj in self.objects_in_pot]
+        )  # return true even if pot is empty
+
+        return len(self.objects_in_pot) < self.capacity and \
+                is_legal_ingredient and is_same_type
 
     def place_on(
         self, agent: grid_object.GridAgent, cell: grid_object.GridObj

--- a/cogrid/test_overcooked_env.py
+++ b/cogrid/test_overcooked_env.py
@@ -202,6 +202,14 @@ class TestOvercookedEnv(unittest.TestCase):
         obs, reward, _, _, _ = self.env.step({0: Actions.PickupDrop, 1: Actions.Noop})
         obs, reward, _, _, _ = self.env.step({0: Actions.MoveRight, 1: Actions.Noop})
         obs, reward, _, _, _ = self.env.step({0: Actions.MoveUp, 1: Actions.Noop})
+
+        # now agent 0 is in front of the pot and facing the pot
+        agent_0 = self.env.grid.grid_agents[0]
+        agent_0_forward_pos = agent_0.front_pos
+        pot_tile = self.env.grid.get(*agent_0_forward_pos)
+
+        # make sure that object in front is a pot
+        self.assertIsInstance(pot_tile, overcooked_grid_objects.Pot)
     
     def test_tomato_in_pot(self):
         """
@@ -279,6 +287,42 @@ class TestOvercookedEnv(unittest.TestCase):
         self.assertEqual(1, 1)
         return
 
+    def test_pot_can_place_on(self):
+        self.pick_tomato_and_move_to_pot()
+
+        # now agent 0 is in front of the pot and facing the pot
+        agent_0 = self.env.grid.grid_agents[0]
+        agent_0_forward_pos = agent_0.front_pos
+        pot_tile = self.env.grid.get(*agent_0_forward_pos)
+
+        # make sure that object in front is a pot
+        self.assertIsInstance(pot_tile, overcooked_grid_objects.Pot)
+
+        # test that we can place a tomato on the pot
+        can_place_tomato = pot_tile.can_place_on(agent_0, overcooked_grid_objects.Tomato())
+        
+        self.assertTrue(can_place_tomato)
+
+        # place the tomato on the pot
+        self.env.step({0: Actions.PickupDrop, 1: Actions.Noop})
+
+        # assert that we can place more tomatoes on the pot
+        can_place_tomato = pot_tile.can_place_on(agent_0, overcooked_grid_objects.Tomato())
+        self.assertTrue(can_place_tomato)
+
+        # assert that we can't place onion since tomato is already on the pot
+        can_place_onion = pot_tile.can_place_on(agent_0, overcooked_grid_objects.Onion())
+        self.assertFalse(can_place_onion)
+
+        return
+    
+    def test_random_actions(self):
+        """
+        Test that random actions are valid and do not crash the environment.
+        """
+        for _ in range(100):
+            action = {0: self.env.action_spaces[0].sample(), 1: self.env.action_spaces[1].sample()}
+            obs, reward, _, _, _ = self.env.step(action)
     
 
 

--- a/cogrid/test_overcooked_env.py
+++ b/cogrid/test_overcooked_env.py
@@ -316,7 +316,7 @@ class TestOvercookedEnv(unittest.TestCase):
 
         return
 
-    def test_delivery_zone(self):
+    def test_delivery_zone_can_place_on(self):
         # agent 0 move right 2 times
         obs, reward, _, _, _ = self.env.step({0: Actions.MoveRight, 1: Actions.Noop})
         obs, reward, _, _, _ = self.env.step({0: Actions.MoveRight, 1: Actions.Noop})
@@ -329,7 +329,7 @@ class TestOvercookedEnv(unittest.TestCase):
         agent_0_forward_pos = agent_0.front_pos
         delivery_zone_tile = self.env.grid.get(*agent_0_forward_pos)
 
-        # make sure that object in front is a pot
+        # make sure that object in front is a delivery zone
         self.assertIsInstance(delivery_zone_tile, overcooked_grid_objects.DeliveryZone)
 
         # put Tomato soup agent inventory

--- a/cogrid/test_overcooked_env.py
+++ b/cogrid/test_overcooked_env.py
@@ -205,7 +205,9 @@ class TestOvercookedEnv(unittest.TestCase):
     
     def test_tomato_in_pot(self):
         """
-        Test that we can get tomato from the stack and put it in the pot 
+        Test that we can get tomato from the stack and put it in the pot.
+
+        Tests Pot.can_place_on() for Tomato objects
         """
         self.pick_tomato_and_move_to_pot()
 
@@ -234,6 +236,13 @@ class TestOvercookedEnv(unittest.TestCase):
         return
     
     def test_cooking_tomato_soup(self):
+        """
+        Test tat puts 3 tomatoes in the pot and then simulates cooking.
+        Lastly, check if the soup is ready and can be picked up.
+
+        Tests Pot.can_pickup_from() for TomatoSoup objects
+        Tests Pot.pick_up_from() for TomatoSoup objects
+        """
         # put a tomato in the pot
         self.pick_tomato_and_move_to_pot()
         self.env.step({0: Actions.PickupDrop, 1: Actions.Noop})

--- a/cogrid/test_overcooked_env.py
+++ b/cogrid/test_overcooked_env.py
@@ -1,0 +1,233 @@
+import sys
+import time
+import unittest
+import functools
+import numpy as np
+from cogrid.core.actions import Actions
+from cogrid.core.directions import Directions
+from cogrid.envs.overcooked import overcooked_grid_objects
+from cogrid.core import grid_object
+
+from cogrid.feature_space import feature
+from cogrid.feature_space import features
+from cogrid.feature_space import feature_space
+from cogrid.envs.overcooked import overcooked_features
+from cogrid.envs.overcooked import overcooked
+from cogrid import cogrid_env
+from cogrid.core import layouts
+from cogrid.envs import registry
+
+layouts.register_layout(
+    "overcooked_cramped_room_v1",
+    [
+        "#######",
+        "#CCUCC#",
+        "#T   O#",
+        "#C   C#",
+        "#C=C@C#",
+        "#######",
+    ],
+)
+
+class NAgentOvercookedFeatureSpace(feature.Feature):
+    """
+    A wrapper class to generate all encoded Overcooked features as a single array.
+
+    For each agent j, calculate:
+
+        - Agent j Direction
+        - Agent j Inventory
+        - Agent j Adjacent to Counter
+        - Agent j Dist to closest {onion, plate, platestack, onionstack, onionsoup, deliveryzone}
+        - Agent j Pot Features for the two closest pots
+            - pot_k_reachable: {0, 1}  # NOTE(chase): This is hardcoded to 1 currently.
+            - pot_k_status: onehot of {empty | full | is_cooking | is_ready}
+            - pot_k_contents: integer of the number of onions in the pot
+            - pot_k_cooking_timer: integer for the number of ts remaining if cooking, 0 if finished, -1 if not cooking
+            - pot_k_distance: (dy, dx) from the player's location
+            - pot_k_location: (row, column) of the pot on the grid
+        - Agent j Distance to other agents j != i
+        - Agent j Position
+
+    The observation is the concatenation of all these features for all players.
+    """
+
+    def __init__(self, env: cogrid_env.CoGridEnv, **kwargs):
+
+        num_agents = env.config["num_agents"]
+
+        self.agent_features = [
+            # Represent the direction of the agent
+            features.AgentDir(),
+            # The current inventory of the agent (max=1 item)
+            overcooked_features.OvercookedInventory(),
+            # One-hot indicator if there is a counter or pot in each of the four cardinal directions
+            overcooked_features.NextToCounter(),
+            overcooked_features.NextToPot(),
+            # The (dy, dx) distance to the closest {onion, plate, platestack, onionstack, onionsoup, deliveryzone}
+            overcooked_features.ClosestObj(
+                focal_object_type=overcooked_grid_objects.Onion, n=4
+            ),
+            overcooked_features.ClosestObj(
+                focal_object_type=overcooked_grid_objects.Plate, n=4
+            ),
+            overcooked_features.ClosestObj(
+                focal_object_type=overcooked_grid_objects.PlateStack, n=2
+            ),
+            overcooked_features.ClosestObj(
+                focal_object_type=overcooked_grid_objects.OnionStack, n=2
+            ),
+            overcooked_features.ClosestObj(
+                focal_object_type=overcooked_grid_objects.OnionSoup, n=4
+            ),
+            overcooked_features.ClosestObj(
+                focal_object_type=overcooked_grid_objects.DeliveryZone, n=2
+            ),
+            overcooked_features.ClosestObj(
+                focal_object_type=grid_object.Counter, n=4
+            ),
+            # All pot features for the closest two pots
+            overcooked_features.NClosestPotFeatures(num_pots=2),
+            # The (dy, dx) distance to the closest other agent
+            overcooked_features.DistToOtherPlayers(
+                num_other_players=num_agents - 1
+            ),
+            # The (row, column) position of the agent
+            features.AgentPosition(),
+            # The direction the agent can move in
+            features.CanMoveDirection(),
+        ]
+
+        full_shape = num_agents * np.sum(
+            [feature.shape for feature in self.agent_features]
+        )
+        #feature_sum = 0
+        #feature_dict = {
+
+        #}
+        #for feature in self.agent_features:
+        #    print(
+        #        f"Feature: {feature.name}, shape: {feature.shape}"
+        #    )
+        #    if feature.name not in feature_dict:
+        #        feature_dict[feature.name] = 0
+        #    feature_dict[feature.name] += 1
+        #    feature_sum += feature.shape[0]
+        #print(f"Total feature shape: {feature_sum}")
+        #print(f"Feature dict: {feature_dict}")
+
+        super().__init__(
+            low=-np.inf,
+            high=np.inf,
+            shape=(full_shape,),
+            name="n_agent_overcooked_features",
+            **kwargs,
+        )
+
+    def generate(
+        self, env: cogrid_env.CoGridEnv, player_id, **kwargs
+    ) -> np.ndarray:
+        player_encodings = [self.generate_player_encoding(env, player_id)]
+
+        for pid in env.agent_ids:
+            if pid == player_id:
+                continue
+            player_encodings.append(self.generate_player_encoding(env, pid))
+
+        encoding = np.hstack(player_encodings).astype(np.float32)
+
+        assert np.array_equal(self.shape, encoding.shape)
+
+        return encoding
+
+    def generate_player_encoding(
+        self, env: cogrid_env.CoGridEnv, player_id: str | int
+    ) -> np.ndarray:
+        encoded_features = []
+        for feature in self.agent_features:
+            encoded_features.append(feature.generate(env, player_id))
+
+        return np.hstack(encoded_features)
+
+feature_space.register_feature(
+    "n_agent_overcooked_features", NAgentOvercookedFeatureSpace
+)
+
+
+N_agent_overcooked_config = {
+    "name": "NAgentOvercooked-V0",
+    "num_agents": 2,
+    "action_set": "cardinal_actions",
+    "features": "n_agent_overcooked_features",
+    "rewards": ["onion_in_pot_reward", "soup_in_dish_reward"],
+    "scope": "overcooked",
+    "grid": {"layout": "overcooked_cramped_room_v1"},
+    "max_steps": 1000,
+}
+
+def make_env(num_agents=4, layout="overcooked_cramped_room_v1", render_mode="human"):
+    config = N_agent_overcooked_config.copy()  # get config obj
+    config["num_agents"] = num_agents
+    config["grid"]["layout"] = layout
+
+    registry.register(
+        "NAgentOvercooked-V0",
+        functools.partial(
+            overcooked.Overcooked, config=config
+        ),
+    )
+    return registry.make(
+        "NAgentOvercooked-V0",
+        render_mode=render_mode,
+    )
+
+def pause_until_keypress():
+    print("Press any key to continue...")
+    while sys.stdin.read(1):
+        break
+
+class TestOvercookedEnv(unittest.TestCase):
+    def setUp(self):
+        self.env = make_env(num_agents=2, layout="overcooked_cramped_room_v1", render_mode="human")
+        self.env.reset()
+    
+    def test_tomato_in_pot(self):
+        """
+        Test that we can get tomato from the stack and put it in the pot 
+        """
+        obs, reward, _, _, _ = self.env.step({0: Actions.MoveLeft, 1: Actions.Noop})
+        time.sleep(1)
+        obs, reward, _, _, _ = self.env.step({0: Actions.PickupDrop, 1: Actions.Noop})
+        # agent 0 move right
+        time.sleep(1)
+        obs, reward, _, _, _ = self.env.step({0: Actions.MoveRight, 1: Actions.Noop})
+        time.sleep(1)
+        # agent 0 move up
+        obs, reward, _, _, _ = self.env.step({0: Actions.MoveUp, 1: Actions.Noop})
+        time.sleep(1)
+
+        # now agent 0 is in front of the pot and facing the pot
+        agent_0 = self.env.grid.grid_agents[0]
+        agent_0_forward_pos = agent_0.front_pos
+        pot_tile = self.env.grid.get(*agent_0_forward_pos)
+
+        self.assertIsInstance(pot_tile, overcooked_grid_objects.Pot)
+
+        can_place_tomato = pot_tile.can_place_on(agent_0, overcooked_grid_objects.Tomato())  
+
+        self.assertTrue(can_place_tomato)
+
+        # agent 0 PickupDrop
+        obs, reward, _, _, _ = self.env.step({0: Actions.PickupDrop, 1: Actions.Noop})
+        pot_tile = self.env.grid.get(*agent_0_forward_pos)
+
+        self.assertTrue(any(  # assert that tomato is in the pot
+            isinstance(obj, overcooked_grid_objects.Tomato)
+            for obj in pot_tile.objects_in_pot
+        ))
+
+        return
+
+
+if __name__ == "__main__":
+    unittest.main() 

--- a/cogrid/test_overcooked_env.py
+++ b/cogrid/test_overcooked_env.py
@@ -315,6 +315,36 @@ class TestOvercookedEnv(unittest.TestCase):
         self.assertFalse(can_place_onion)
 
         return
+
+    def test_delivery_zone(self):
+        # agent 0 move right 2 times
+        obs, reward, _, _, _ = self.env.step({0: Actions.MoveRight, 1: Actions.Noop})
+        obs, reward, _, _, _ = self.env.step({0: Actions.MoveRight, 1: Actions.Noop})
+        # agent 0 move down 1 time
+        obs, reward, _, _, _ = self.env.step({0: Actions.MoveDown, 1: Actions.Noop})
+
+
+        # now agent 0 is in front of the delivery zone
+        agent_0 = self.env.grid.grid_agents[0]
+        agent_0_forward_pos = agent_0.front_pos
+        delivery_zone_tile = self.env.grid.get(*agent_0_forward_pos)
+
+        # make sure that object in front is a pot
+        self.assertIsInstance(delivery_zone_tile, overcooked_grid_objects.DeliveryZone)
+
+        # put Tomato soup agent inventory
+        agent_0.inventory.append(overcooked_grid_objects.TomatoSoup())
+
+        # test that we can place a tomato soup on the delivery zone
+        can_place_tomato_soup = delivery_zone_tile.can_place_on(agent_0, overcooked_grid_objects.TomatoSoup())
+        self.assertTrue(can_place_tomato_soup)
+
+        # put onion soup agent inventory
+        agent_0.inventory[0] = overcooked_grid_objects.OnionSoup()
+        # test that we can place a onion soup on the delivery zone
+        can_place_onion_soup = delivery_zone_tile.can_place_on(agent_0, overcooked_grid_objects.OnionSoup())
+        self.assertTrue(can_place_onion_soup)
+        return
     
     def test_random_actions(self):
         """


### PR DESCRIPTION
# May 9 2025
## Extend Overcooked object for Tomato, TomatoStack, and TomatoSoup

**Changed**
- [x]  `overcooked_grid_objects.py`: Tomato, TomatoStack, TomatoSoup. Symbol (o, O, !) respectively.
- [x] `overcooked_grid_objects.py`: Pot.can_pickup_from(), Pot.pick_up_from() accommodate for tomatoes.

**Tests**
 `Test_overcooked_env.py`: to unittest refractored features. 

- [x] Pot.can_pickup_from()
- [x] Pot.pick_up_from()
- [x] Pot.can_place()
- [x] Cooking tomato soup
- [x] Delivery_zone.can_place_on()